### PR TITLE
Feat/add-async-adapter

### DIFF
--- a/async_casbin_sqlmodel_adapter/__init__.py
+++ b/async_casbin_sqlmodel_adapter/__init__.py
@@ -1,2 +1,3 @@
 # Localfolder:
 from .adapter import Adapter, AdapterException, Filter  # noqa: F401
+from .async_adapter import AsyncAdapter, AsyncAdapterException, AsyncFilter  # noqa: F401

--- a/async_casbin_sqlmodel_adapter/__init__.py
+++ b/async_casbin_sqlmodel_adapter/__init__.py
@@ -1,3 +1,3 @@
 # Localfolder:
 from .adapter import Adapter, AdapterException, Filter  # noqa: F401
-from .async_adapter import AsyncAdapter, AsyncAdapterException, AsyncFilter  # noqa: F401
+from .async_adapter import AsyncAdapter # noqa: F401

--- a/async_casbin_sqlmodel_adapter/adapter.py
+++ b/async_casbin_sqlmodel_adapter/adapter.py
@@ -11,24 +11,10 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.dml import Delete
 from sqlmodel import SQLModel, delete, or_, select
 from sqlmodel.sql.expression import SelectOfScalar
+from .exception import AdapterException
+from .filter import Filter
 
 
-class AdapterException(Exception):
-    """AdapterException"""
-
-
-class Filter:  # pylint: disable=too-few-public-methods
-    """
-    Filter class for SQLModel-based Casbin adapter.
-    """
-
-    ptype: list[str] = []
-    v0: list[str] = []
-    v1: list[str] = []
-    v2: list[str] = []
-    v3: list[str] = []
-    v4: list[str] = []
-    v5: list[str] = []
 
 
 class Adapter(BaseAdapter, UpdateAdapter):

--- a/async_casbin_sqlmodel_adapter/async_adapter.py
+++ b/async_casbin_sqlmodel_adapter/async_adapter.py
@@ -10,23 +10,8 @@ from sqlalchemy.sql.dml import Delete
 from sqlmodel import SQLModel, delete, or_, select
 from sqlmodel.sql.expression import SelectOfScalar
 from casbin.persist.adapters.asyncio import AsyncUpdateAdapter as BaseAsyncUpdateAdapter, AsyncAdapter as BaseAsyncAdapter
-
-class AdapterException(Exception):
-    """AdapterException"""
-
-
-class Filter:  # pylint: disable=too-few-public-methods
-    """
-    Filter class for SQLModel-based Casbin adapter.
-    """
-
-    ptype: list[str] = []
-    v0: list[str] = []
-    v1: list[str] = []
-    v2: list[str] = []
-    v3: list[str] = []
-    v4: list[str] = []
-    v5: list[str] = []
+from .exception import AdapterException
+from .filter import Filter
 
 
 class AsyncAdapter(BaseAsyncAdapter, BaseAsyncUpdateAdapter):

--- a/async_casbin_sqlmodel_adapter/async_adapter.py
+++ b/async_casbin_sqlmodel_adapter/async_adapter.py
@@ -251,3 +251,28 @@ class AsyncAdapter(BaseAsyncAdapter, BaseAsyncUpdateAdapter):
 
         for i, rule in enumerate(old_rules):
             await self.update_policy(sec, ptype, rule, new_rules[i])
+
+    async def update_filtered_policies(
+        self,
+        sec: str,
+        ptype: str,
+        new_rules: list[list[str]],
+        field_index: int,
+        *field_values: str
+    ) -> None:
+        """
+        Update the filtered policies in the database (storage).
+        Deletes old rules that match the filter and adds new rules.
+        :param sec: section type
+        :param ptype: policy type
+        :param new_rules: the new rules to add
+        :param field_index: the index of the field to filter on
+        :param field_values: the values of the field to filter on
+        :return: None
+        """
+
+        # Remove old rules that match the filter
+        await self.remove_filtered_policy(sec, ptype, field_index, *field_values)
+
+        # Add new rules
+        await self.add_policies(sec, ptype, new_rules)

--- a/async_casbin_sqlmodel_adapter/async_adapter.py
+++ b/async_casbin_sqlmodel_adapter/async_adapter.py
@@ -1,0 +1,268 @@
+# Stdlib:
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+# Thirdparty:
+from casbin import Model, persist
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql.dml import Delete
+from sqlmodel import SQLModel, delete, or_, select
+from sqlmodel.sql.expression import SelectOfScalar
+from casbin.persist.adapters.asyncio import AsyncUpdateAdapter as BaseAsyncUpdateAdapter, AsyncAdapter as BaseAsyncAdapter
+
+class AdapterException(Exception):
+    """AdapterException"""
+
+
+class Filter:  # pylint: disable=too-few-public-methods
+    """
+    Filter class for SQLModel-based Casbin adapter.
+    """
+
+    ptype: list[str] = []
+    v0: list[str] = []
+    v1: list[str] = []
+    v2: list[str] = []
+    v3: list[str] = []
+    v4: list[str] = []
+    v5: list[str] = []
+
+
+class AsyncAdapter(BaseAsyncAdapter, BaseAsyncUpdateAdapter):
+    """
+    Adapter class for ormar-based Casbin adapter.
+    """
+
+    cols = ["ptype"] + [f"v{i}" for i in range(6)]
+
+    def __init__(
+        self,
+        engine: AsyncEngine | str,
+        db_class: SQLModel | None = None,
+        filtered: bool = False,
+    ):
+        if isinstance(engine, str):
+            self._engine = create_async_engine(engine)
+        else:
+            self._engine = engine
+
+        if db_class is None:
+            from .models import (  # isort: skip # pylint: disable=import-outside-toplevel
+                CasbinRule,
+            )
+
+            db_class = CasbinRule
+        else:
+            for attr in (
+                "id",
+                "ptype",
+                "v0",
+                "v1",
+                "v2",
+                "v3",
+                "v4",
+                "v5",
+            ):  # id attr was used by filter
+                if not hasattr(db_class, attr):
+                    raise AdapterException(f"{attr} not found in custom DatabaseClass.")
+
+        self._db_class = db_class
+        self.session_local = sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+        self._filtered: bool = filtered
+
+    @asynccontextmanager
+    async def _session_scope(self) -> AsyncGenerator[AsyncSession, None]:
+        """Provide a transactional scope around a series of operations."""
+
+        async with self.session_local() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception as err:  # pragma: no cover
+                await session.rollback()
+                raise err
+            finally:
+                await session.close()
+
+    async def load_policy(self, model: Model) -> None:
+        """loads all policy rules from the storage."""
+
+        async with self._session_scope() as session:
+            lines = (await session.execute(select(self._db_class))).scalars().all()
+            for line in lines:
+                persist.load_policy_line(str(line), model)
+
+    def is_filtered(self) -> bool:
+        """returns whether the adapter is filtered or not."""
+
+        return self._filtered
+
+    async def load_filtered_policy(self, model: Model, filter_: Filter) -> None:
+        """loads all policy rules from the storage."""
+
+        async with self._session_scope() as session:
+            query: SelectOfScalar = select(self._db_class)
+            filters = await self.filter_query(query, filter_)
+            filters = (await session.execute(filters)).scalars().all()
+
+            for line in filters:
+                persist.load_policy_line(str(line), model)
+            self._filtered = True
+
+    async def filter_query(
+        self, querydb: SelectOfScalar, filter_: Filter
+    ) -> SelectOfScalar:
+        """filters the query based on the filter_."""
+
+        for attr in ("ptype", "v0", "v1", "v2", "v3", "v4", "v5"):
+            if len(getattr(filter_, attr)) > 0:
+                querydb = querydb.filter(
+                    getattr(self._db_class, attr).in_(getattr(filter_, attr))
+                )
+        return querydb.order_by(self._db_class.id)
+
+    async def _save_policy_line(self, ptype: str, rule: list[str]) -> None:
+        async with self._session_scope() as session:
+            line = self._db_class(ptype=ptype)
+            for i, v in enumerate(rule):  # pylint: disable=invalid-name
+                setattr(line, f"v{i}", v)
+            session.add(line)
+
+    async def save_policy(self, model: Model) -> bool:
+        """saves all policy rules to the storage."""
+
+        async with self._session_scope() as session:
+            query: SelectOfScalar = select(self._db_class)
+            results = (await session.execute(query)).scalars().all()
+            for line in results:
+                await session.delete(line)
+            for sec in ["p", "g"]:
+                if sec not in model.model.keys():  # pragma: no cover
+                    continue
+                for ptype, ast in model.model[sec].items():
+                    for rule in ast.policy:
+                        await self._save_policy_line(ptype, rule)
+        return True
+
+    # pylint: disable=unused-argument
+    async def add_policy(self, sec: str, ptype: str, rule: list[str]) -> None:
+        """adds a policy rule to the storage."""
+
+        await self._save_policy_line(ptype, rule)
+
+    # pylint: disable=unused-argument
+    async def add_policies(
+        self, sec: str, ptype: str, rules: tuple[tuple[str]]
+    ) -> None:
+        """adds a policy rules to the storage."""
+
+        for rule in rules:
+            await self._save_policy_line(ptype, list(rule))
+
+    # pylint: disable=unused-argument
+    async def remove_policy(self, sec: str, ptype: str, rule: list[str]) -> bool:
+        """removes a policy rule from the storage."""
+
+        async with self._session_scope() as session:
+            query: Delete = delete(self._db_class)
+            query = query.filter(self._db_class.ptype == ptype)
+            for i, v in enumerate(rule):  # pylint: disable=invalid-name
+                query = query.filter(getattr(self._db_class, f"v{i}") == v)
+            res = (await session.execute(query)).rowcount
+        return res > 0  # pragma: no cover
+
+    async def remove_policies(
+        self, sec: str, ptype: str, rules: tuple[tuple[str]]
+    ) -> None:
+        """remove policy rules from the storage."""
+
+        if not rules:  # pragma: no cover
+            return
+        async with self._session_scope() as session:
+            query: Delete = delete(self._db_class)
+            query = query.filter(self._db_class.ptype == ptype)
+            _rules = zip(*rules)
+            for i, rule in enumerate(_rules):
+                query = query.filter(
+                    or_(getattr(self._db_class, f"v{i}") == v for v in rule)
+                )
+            await session.execute(query)
+
+    # pylint: disable=unused-argument
+    async def remove_filtered_policy(
+        self, sec: str, ptype: str, field_index: int, *field_values: tuple[str]
+    ) -> bool:
+        """removes policy rules that match the filter from the storage.
+        This is part of the Auto-Save feature.
+        """
+
+        async with self._session_scope() as session:
+            query: Delete = delete(self._db_class)
+            query = query.filter(self._db_class.ptype == ptype)
+
+            if not 0 <= field_index <= 5:  # pragma: no cover
+                return False
+            if not 1 <= field_index + len(field_values) <= 6:  # pragma: no cover
+                return False
+            for i, v in enumerate(field_values):  # pylint: disable=invalid-name
+                if v != "":
+                    v_value = getattr(self._db_class, f"v{field_index + i}")
+                    query = query.filter(v_value == v)
+            res = (await session.execute(query)).rowcount
+
+        return res > 0
+
+    async def update_policy(
+        self, sec: str, ptype: str, old_rule: list[str], new_rule: list[str]
+    ) -> None:
+        """
+        Update the old_rule with the new_rule in the database (storage).
+        :param sec: section type
+        :param ptype: policy type
+        :param old_rule: the old rule that needs to be modified
+        :param new_rule: the new rule to replace the old rule
+        :return: None
+        """
+
+        async with self._session_scope() as session:
+            query: SelectOfScalar = select(self._db_class)
+            query = query.filter(self._db_class.ptype == ptype)
+
+            # locate the old rule
+            for index, value in enumerate(old_rule):
+                v_value = getattr(self._db_class, f"v{index}")
+                query = query.filter(v_value == value)
+
+            # need the length of the longest_rule to perform overwrite
+            longest_rule = old_rule if len(old_rule) > len(new_rule) else new_rule
+            results = await session.execute(query)
+            old_rule_line = results.scalar_one()
+
+            # overwrite the old rule with the new rule
+            for index in range(len(longest_rule)):
+                if index < len(new_rule):
+                    setattr(old_rule_line, f"v{index}", new_rule[index])
+                else:  # pragma: no cover
+                    setattr(old_rule_line, f"v{index}", None)
+
+    async def update_policies(
+        self,
+        sec: str,
+        ptype: str,
+        old_rules: list[list[str]],
+        new_rules: list[list[str]],
+    ) -> None:
+        """
+        Update the old_rules with the new_rules in the database (storage).
+        :param sec: section type
+        :param ptype: policy type
+        :param old_rules: the old rules that need to be modified
+        :param new_rules: the new rules to replace the old rules
+        :return: None
+        """
+
+        for i, rule in enumerate(old_rules):
+            await self.update_policy(sec, ptype, rule, new_rules[i])

--- a/async_casbin_sqlmodel_adapter/exception.py
+++ b/async_casbin_sqlmodel_adapter/exception.py
@@ -1,0 +1,2 @@
+class AdapterException(Exception):
+    """AdapterException"""

--- a/async_casbin_sqlmodel_adapter/filter.py
+++ b/async_casbin_sqlmodel_adapter/filter.py
@@ -1,0 +1,12 @@
+class Filter:  # pylint: disable=too-few-public-methods
+    """
+    Filter class for SQLModel-based Casbin adapter.
+    """
+
+    ptype: list[str] = []
+    v0: list[str] = []
+    v1: list[str] = []
+    v2: list[str] = []
+    v3: list[str] = []
+    v4: list[str] = []
+    v5: list[str] = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -69,6 +69,20 @@ files = [
 ]
 
 [[package]]
+name = "casbin"
+version = "1.35.0"
+description = "An authorization library that supports access control models like ACL, RBAC, ABAC in Python"
+optional = false
+python-versions = ">=3.3"
+files = [
+    {file = "casbin-1.35.0-py3-none-any.whl", hash = "sha256:e17f365b439f430f8bbde533e580dc1eb85cf1da5e5c830aafad3b1acec00cb7"},
+    {file = "casbin-1.35.0.tar.gz", hash = "sha256:73c5bb375154019af9ba87a5e05aa12cdae28227c5466228aa76d361182653cc"},
+]
+
+[package.dependencies]
+simpleeval = ">=0.9.11"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -484,6 +498,17 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "simpleeval"
+version = "0.9.13"
+description = "A simple, safe single expression evaluator library."
+optional = false
+python-versions = "*"
+files = [
+    {file = "simpleeval-0.9.13-py2.py3-none-any.whl", hash = "sha256:22a2701a5006e4188d125d34accf2405c2c37c93f6b346f2484b6422415ae54a"},
+    {file = "simpleeval-0.9.13.tar.gz", hash = "sha256:4a30f9cc01825fe4c719c785e3762623e350c4840d5e6855c2a8496baaa65fac"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.25"
 description = "Database Abstraction Library"
@@ -636,4 +661,4 @@ bracex = ">=2.1.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a2441a99879d26e0c4d688a9af15a2bca36121dae5749f872da28c2776af769b"
+content-hash = "b98f85a3082f6d80e5c378bdc31ae4a2219f19821029a1f4653a9194bdf51955"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-casbin-sqlmodel-adapter"
-version = "0.0.5"
+version = "0.1.0"
 description = "Async SQLModel Adapter for PyCasbin"
 authors = ["Vladislav Shepilov <shepilov.v@protonmail.com>"]
 keywords = ["pycasbin", "asynccasbin", "sqlmodel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ python = "^3.10"
 asynccasbin = "^1.1.8"
 sqlmodel = "^0.0.14"
 SQLAlchemy = {version = "^2.0.25", extras = ["mypy", "asyncio"]}
+casbin = "^1.35.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-casbin-sqlmodel-adapter"
-version = "0.1.0"
+version = "0.1.1"
 description = "Async SQLModel Adapter for PyCasbin"
 authors = ["Vladislav Shepilov <shepilov.v@protonmail.com>"]
 keywords = ["pycasbin", "asynccasbin", "sqlmodel"]

--- a/tests/test_async_adapter.py
+++ b/tests/test_async_adapter.py
@@ -1,0 +1,350 @@
+# Stdlib:
+import re
+
+# Thirdparty:
+import pytest
+from casbin import AsyncEnforcer
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlmodel import SQLModel, select
+
+# Firstparty:
+from async_casbin_sqlmodel_adapter import AsyncAdapter, AdapterException, Filter
+from async_casbin_sqlmodel_adapter.models import CasbinRule
+
+
+async def test_custom_db_class(
+    engine: AsyncEngine, session: AsyncSession, CustomRule, CustomRuleBroken
+):
+    with pytest.raises(AdapterException):
+        AsyncAdapter("sqlite+aiosqlite:///", CustomRuleBroken)
+
+    adapter = AsyncAdapter(engine, CustomRule)
+    assert adapter._db_class == CustomRule
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session.add(CustomRule(not_exist="NotNone"))
+    await session.commit()
+
+    from_db: CustomRule = (await session.execute(select(CustomRule))).scalars().all()[0]
+    assert from_db.not_exist == "NotNone"
+
+
+async def test_enforcer_basic(async_enforcer: AsyncEnforcer):
+    assert async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert async_enforcer.enforce("alice", "data2", "read")
+    assert async_enforcer.enforce("alice", "data2", "write")
+
+
+async def test_add_policy(async_enforcer: AsyncEnforcer):
+    assert not async_enforcer.enforce("eve", "data3", "read")
+    res = await async_enforcer.add_policies(
+        (("eve", "data3", "read"), ("eve", "data4", "read"))
+    )
+    assert res
+    assert async_enforcer.enforce("eve", "data3", "read")
+    assert async_enforcer.enforce("eve", "data4", "read")
+
+
+async def test_add_policies(async_enforcer: AsyncEnforcer):
+    assert not async_enforcer.enforce("eve", "data3", "read")
+    res = await async_enforcer.add_permission_for_user("eve", "data3", "read")
+    assert res
+    assert async_enforcer.enforce("eve", "data3", "read")
+
+
+async def test_save_policy(async_enforcer: AsyncEnforcer):
+    assert not async_enforcer.enforce("alice", "data4", "read")
+
+    model = async_enforcer.get_model()
+    model.clear_policy()
+
+    model.add_policy("p", "p", ["alice", "data4", "read"])
+
+    adapter = async_enforcer.get_adapter()
+    await adapter.save_policy(model)
+    assert async_enforcer.enforce("alice", "data4", "read")
+
+
+async def test_remove_policy(async_enforcer: AsyncEnforcer):
+    assert not async_enforcer.enforce("alice", "data5", "read")
+    assert not await async_enforcer.delete_permission_for_user("alice", "data5", "read")
+    await async_enforcer.add_permission_for_user("alice", "data5", "read")
+    assert async_enforcer.enforce("alice", "data5", "read")
+    assert await async_enforcer.delete_permission_for_user("alice", "data5", "read")
+    assert not async_enforcer.enforce("alice", "data5", "read")
+
+
+async def test_remove_policies(async_enforcer: AsyncEnforcer):
+    assert not async_enforcer.enforce("alice", "data5", "read")
+    assert not async_enforcer.enforce("alice", "data6", "read")
+    await async_enforcer.add_policies(
+        (("alice", "data5", "read"), ("alice", "data6", "read"))
+    )
+    assert async_enforcer.enforce("alice", "data5", "read")
+    assert async_enforcer.enforce("alice", "data6", "read")
+    assert await async_enforcer.remove_policies(
+        (("alice", "data5", "read"), ("alice", "data6", "read"))
+    )
+    assert not async_enforcer.enforce("alice", "data5", "read")
+    assert not async_enforcer.enforce("alice", "data6", "read")
+
+
+async def test_remove_filtered_policy(async_enforcer: AsyncEnforcer):
+    assert async_enforcer.enforce("alice", "data1", "read")
+    await async_enforcer.remove_filtered_policy(1, "data1")
+    assert not async_enforcer.enforce("alice", "data1", "read")
+
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert async_enforcer.enforce("alice", "data2", "read")
+    assert async_enforcer.enforce("alice", "data2", "write")
+
+    await async_enforcer.remove_filtered_policy(1, "data2", "read")
+
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert async_enforcer.enforce("alice", "data2", "write")
+
+    await async_enforcer.remove_filtered_policy(2, "write")
+
+    assert not async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+
+    # await async_enforcer.add_permission_for_user("alice", "data6", "delete")
+    # await async_enforcer.add_permission_for_user("bob", "data6", "delete")
+    # await async_enforcer.add_permission_for_user("eve", "data6", "delete")
+    # assert async_enforcer.enforce("alice", "data6", "delete")
+    # assert async_enforcer.enforce("bob", "data6", "delete")
+    # assert async_enforcer.enforce("eve", "data6", "delete")
+    # await async_enforcer.remove_filtered_policy(0, "alice", None, "delete")
+    # assert not async_enforcer.enforce("alice", "data6", "delete")
+    # await async_enforcer.remove_filtered_policy(0, None, None, "delete")
+    # assert not async_enforcer.enforce("bob", "data6", "delete")
+    # assert not async_enforcer.enforce("eve", "data6", "delete")
+
+
+async def test_str():
+    rule = CasbinRule(ptype="p", v0="alice", v1="data1", v2="read")
+    assert str(rule) == "p, alice, data1, read"
+    rule = CasbinRule(ptype="p", v0="bob", v1="data2", v2="write")
+    assert str(rule) == "p, bob, data2, write"
+    rule = CasbinRule(ptype="p", v0="data2_admin", v1="data2", v2="read")
+    assert str(rule) == "p, data2_admin, data2, read"
+    rule = CasbinRule(ptype="p", v0="data2_admin", v1="data2", v2="write")
+    assert str(rule) == "p, data2_admin, data2, write"
+    rule = CasbinRule(ptype="g", v0="alice", v1="data2_admin")
+    assert str(rule) == "g, alice, data2_admin"
+
+
+async def test_repr(engine: AsyncEngine, session: AsyncSession):
+    rule = CasbinRule(ptype="p", v0="alice", v1="data1", v2="read")
+    assert repr(rule) == '<CasbinRule None: "p, alice, data1, read">'
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    session.add(rule)
+    await session.commit()
+    re.search(repr(rule), r'<CasbinRule \d+: "p, alice, data1, read">')
+    await session.close()
+
+
+async def test_filtered_policy(async_enforcer: AsyncEnforcer):
+    filter = Filter()
+
+    filter.ptype = ["p"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert async_enforcer.enforce("bob", "data2", "write")
+
+    filter.ptype = []
+    filter.v0 = ["alice"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert not async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("data2_admin", "data2", "read")
+    assert not async_enforcer.enforce("data2_admin", "data2", "write")
+
+    filter.v0 = ["bob"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert not async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("data2_admin", "data2", "read")
+    assert not async_enforcer.enforce("data2_admin", "data2", "write")
+
+    filter.v0 = ["data2_admin"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert async_enforcer.enforce("data2_admin", "data2", "read")
+    assert async_enforcer.enforce("data2_admin", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert not async_enforcer.enforce("bob", "data2", "write")
+
+    filter.v0 = ["alice", "bob"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("data2_admin", "data2", "read")
+    assert not async_enforcer.enforce("data2_admin", "data2", "write")
+
+    filter.v0 = []
+    filter.v1 = ["data1"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert not async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("data2_admin", "data2", "read")
+    assert not async_enforcer.enforce("data2_admin", "data2", "write")
+
+    filter.v1 = ["data2"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert not async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert async_enforcer.enforce("data2_admin", "data2", "read")
+    assert async_enforcer.enforce("data2_admin", "data2", "write")
+
+    filter.v1 = []
+    filter.v2 = ["read"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert not async_enforcer.enforce("bob", "data2", "write")
+    assert async_enforcer.enforce("data2_admin", "data2", "read")
+    assert not async_enforcer.enforce("data2_admin", "data2", "write")
+
+    filter.v2 = ["write"]
+    await async_enforcer.load_filtered_policy(filter)
+    assert not async_enforcer.enforce("alice", "data1", "read")
+    assert not async_enforcer.enforce("alice", "data1", "write")
+    assert not async_enforcer.enforce("alice", "data2", "read")
+    assert not async_enforcer.enforce("alice", "data2", "write")
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    assert not async_enforcer.enforce("bob", "data2", "read")
+    assert async_enforcer.enforce("bob", "data2", "write")
+    assert not async_enforcer.enforce("data2_admin", "data2", "read")
+    assert async_enforcer.enforce("data2_admin", "data2", "write")
+
+
+async def test_update_policy(async_enforcer: AsyncEnforcer):
+    example_p = ["mike", "cookie", "eat"]
+
+    assert async_enforcer.enforce("alice", "data1", "read")
+    await async_enforcer.update_policy(
+        ["alice", "data1", "read"], ["alice", "data1", "no_read"]
+    )
+    assert not async_enforcer.enforce("alice", "data1", "read")
+
+    assert not async_enforcer.enforce("bob", "data1", "read")
+    await async_enforcer.add_policy(example_p)
+    await async_enforcer.update_policy(example_p, ["bob", "data1", "read"])
+    assert async_enforcer.enforce("bob", "data1", "read")
+
+    assert not async_enforcer.enforce("bob", "data1", "write")
+    await async_enforcer.update_policy(["bob", "data1", "read"], ["bob", "data1", "write"])
+    assert async_enforcer.enforce("bob", "data1", "write")
+
+    assert async_enforcer.enforce("bob", "data2", "write")
+    await async_enforcer.update_policy(["bob", "data2", "write"], ["bob", "data2", "read"])
+    assert not async_enforcer.enforce("bob", "data2", "write")
+
+    assert async_enforcer.enforce("bob", "data2", "read")
+    await async_enforcer.update_policy(["bob", "data2", "read"], ["carl", "data2", "write"])
+    assert not async_enforcer.enforce("bob", "data2", "write")
+
+    assert async_enforcer.enforce("carl", "data2", "write")
+    await async_enforcer.update_policy(
+        ["carl", "data2", "write"], ["carl", "data2", "no_write"]
+    )
+    assert not async_enforcer.enforce("bob", "data2", "write")
+
+
+async def test_update_policies(async_enforcer: AsyncEnforcer):
+    old_rule_0 = ["alice", "data1", "read"]
+    old_rule_1 = ["bob", "data2", "write"]
+    old_rule_2 = ["data2_admin", "data2", "read"]
+    old_rule_3 = ["data2_admin", "data2", "write"]
+
+    new_rule_0 = ["alice", "data_test", "read"]
+    new_rule_1 = ["bob", "data_test", "write"]
+    new_rule_2 = ["data2_admin", "data_test", "read"]
+    new_rule_3 = ["data2_admin", "data_test", "write"]
+
+    old_rules = [old_rule_0, old_rule_1, old_rule_2, old_rule_3]
+    new_rules = [new_rule_0, new_rule_1, new_rule_2, new_rule_3]
+
+    await async_enforcer.update_policies(old_rules, new_rules)
+
+    assert not async_enforcer.enforce("alice", "data1", "read")
+    assert async_enforcer.enforce("alice", "data_test", "read")
+
+    assert not async_enforcer.enforce("bob", "data2", "write")
+    assert async_enforcer.enforce("bob", "data_test", "write")
+
+    assert not async_enforcer.enforce("data2_admin", "data2", "read")
+    assert async_enforcer.enforce("data2_admin", "data_test", "read")
+
+    assert not async_enforcer.enforce("data2_admin", "data2", "write")
+    assert async_enforcer.enforce("data2_admin", "data_test", "write")
+
+
+async def test_is_filtered(engine: AsyncEngine, session: AsyncSession, rbac_model_conf):
+    adapter1 = AsyncAdapter(engine)
+    enforcer1 = AsyncEnforcer(rbac_model_conf, adapter1)
+    await enforcer1.load_policy()
+    assert not enforcer1.is_filtered()
+
+    adapter1 = AsyncAdapter(engine, filtered=True)
+    enforcer1 = AsyncEnforcer(rbac_model_conf, adapter1)
+    await enforcer1.load_policy()
+    assert enforcer1.is_filtered()


### PR DESCRIPTION
# pre
- merge pr #1 first

# rationale
fix this error
```
File "/home/nam/UnixDev/whale/Backend/.venv/lib/python3.11/site-packages/casbin/core_enforcer.py", line 39, in __init__
    self.init_with_model_and_adapter(model, adapter)
  File "/home/nam/UnixDev/whale/Backend/.venv/lib/python3.11/site-packages/casbin/async_internal_enforcer.py", line 35, in init_with_model_and_adapter
    raise RuntimeError("Invalid parameters for enforcer.")
RuntimeError: Invalid parameters for enforcer.
```
in lastest casbin code
```
class AsyncInternalEnforcer(CoreEnforcer):
    """
    AsyncInternalEnforcer = CoreEnforcer + Async Internal API.
    """

    def init_with_file(self, model_path, policy_path):
        """initializes an enforcer with a model file and a policy file."""
        a = AsyncFileAdapter(policy_path)
        self.init_with_adapter(model_path, a)

    def init_with_model_and_adapter(self, m, adapter=None):
        """initializes an enforcer with a model and a database adapter."""

        if not isinstance(m, Model) or adapter is not None and not isinstance(adapter, AsyncAdapter):
            raise RuntimeError("Invalid parameters for enforcer.")

        self.adapter = adapter

        self.model = m
        self.model.print_model()
        self.fm = FunctionMap.load_function_map()

        self._initialize()
```